### PR TITLE
Implement one variant of DSP Pipe 2 Channel 3 (Binary Pipe)

### DIFF
--- a/src/audio_core/hle/pipe.cpp
+++ b/src/audio_core/hle/pipe.cpp
@@ -161,6 +161,9 @@ void PipeWrite(DspPipe pipe_number, const std::vector<u8>& buffer) {
 
         return;
     }
+    case DspPipe::Binary:
+        std::copy(buffer.begin(), buffer.end(), std::back_inserter(pipe_data[static_cast<size_t>(DspPipe::Binary)]));
+        return;
     default:
         LOG_CRITICAL(Audio_DSP, "pipe_number = %zu unimplemented",
                      static_cast<size_t>(pipe_number));


### PR DESCRIPTION
14 lines of the commit are known to be correct (known dsp::DSP behaviour). The other 3 lines was guesswork.

This is here because it improves compatibility with things even though we've no real idea what it does.

Poke me on IRC/Discord if there are any issues.